### PR TITLE
Exposed an action to configure the HttpClientBuilder that is returned…

### DIFF
--- a/AccessTokenClient.Extensions/AccessTokenClient.Extensions.csproj
+++ b/AccessTokenClient.Extensions/AccessTokenClient.Extensions.csproj
@@ -20,12 +20,14 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.1.1" />
     <PackageReference Include="Scrutor" Version="3.2.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="3.1.1" />
     <PackageReference Include="Scrutor" Version="3.2.1" />
   </ItemGroup>
 

--- a/AccessTokenClient.Extensions/AccessTokenClientPolicy.cs
+++ b/AccessTokenClient.Extensions/AccessTokenClientPolicy.cs
@@ -1,0 +1,33 @@
+﻿using Polly;
+using Polly.Extensions.Http;
+using System;
+using System.Net;
+using System.Net.Http;
+
+namespace AccessTokenClient.Extensions
+{
+    /// <summary>
+    /// This static class contains policies that can be applied
+    /// easily to the access token client to increase resiliency.
+    /// </summary>
+    public static class AccessTokenClientPolicy
+    {
+        /// <summary>
+        /// Returns the default retry policy for the access token client.
+        /// </summary>
+        /// <returns>
+        /// A default <see cref="IAsyncPolicy{TResult}"/> that can be applied to the
+        /// <see cref="HttpClient"/> instance that is injected into the access token client.
+        /// This policy retries the token request in the event of transient http errors
+        /// (5XX and 408) as well as when a 404 is encountered. The request will be retried
+        /// twice, with a 1 second wait time between retries.
+        /// </returns>
+        public static IAsyncPolicy<HttpResponseMessage> GetDefaultRetryPolicy()
+        {
+            return HttpPolicyExtensions
+                .HandleTransientHttpError()
+                .OrResult(message => message.StatusCode == HttpStatusCode.NotFound)
+                .WaitAndRetryAsync(2, retryAttempt => TimeSpan.FromSeconds(1));
+        }
+    }
+}

--- a/AccessTokenClient.Extensions/TokenClientOptions.cs
+++ b/AccessTokenClient.Extensions/TokenClientOptions.cs
@@ -1,5 +1,8 @@
 ﻿namespace AccessTokenClient.Extensions
 {
+    /// <summary>
+    /// Options that can be used to configure the access token client. 
+    /// </summary>
     public class TokenClientOptions
     {
         /// <summary>

--- a/AccessTokenClient/TokenResponse.cs
+++ b/AccessTokenClient/TokenResponse.cs
@@ -2,6 +2,9 @@
 
 namespace AccessTokenClient
 {
+    /// <summary>
+    /// A class that represents the response from a token endpoint.
+    /// </summary>
     public class TokenResponse
     {
         /// <summary>

--- a/Projects/TestingThreePointOneApplication/Startup.cs
+++ b/Projects/TestingThreePointOneApplication/Startup.cs
@@ -22,7 +22,10 @@ namespace TestingThreePointOneApplication
         {
             services.AddMemoryCache();
 
-            services.AddAccessTokenClient();
+            services.AddAccessTokenClient(builderAction: builder =>
+            {
+                builder.AddPolicyHandler(AccessTokenClientPolicy.GetDefaultRetryPolicy());
+            });
 
             // Register the options for the client:
             services.AddSingleton(new TestingClientOptions
@@ -34,7 +37,9 @@ namespace TestingThreePointOneApplication
             });
 
             // Register the client and specify that the access token delegating handler be used:
-            services.AddHttpClient<ITestingClient, TestingClient>().AddClientAccessTokenHandler<TestingClientOptions>();
+            services
+                .AddHttpClient<ITestingClient, TestingClient>()
+                .AddClientAccessTokenHandler<TestingClientOptions>();
 
             services.AddControllers();
         }


### PR DESCRIPTION
… when registering the TokenClient class in the service collection via the AddHttpClient extension method. This can be used to add a retry policy to the injected HttpClient to add resiliancy.